### PR TITLE
fix README packer typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Open localhost:12344 in browser to view the dummy server's response.
 
 ```packer init .```
 
-```packer build packer.pkg.hcl```
+```packer build packer.pkr.hcl```


### PR DESCRIPTION
github actions should build docker image and AMI